### PR TITLE
wlx: Add mpv_wayland plugin for native Qt6 rendering over libmpv

### DIFF
--- a/plugins/wlx/mpv_wayland/.gitignore
+++ b/plugins/wlx/mpv_wayland/.gitignore
@@ -1,0 +1,8 @@
+build/
+.vscode/
+compile_commands.json
+CMakeCache.txt
+CMakeFiles/
+cmake_install.cmake
+Makefile
+.*.swp

--- a/plugins/wlx/mpv_wayland/CMakeLists.txt
+++ b/plugins/wlx/mpv_wayland/CMakeLists.txt
@@ -1,0 +1,42 @@
+cmake_minimum_required(VERSION 3.16)
+project(mpv_wayland LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_AUTOMOC ON)
+
+# Double Commander plugins are usually built without name prefix (lib) and with .wlx extension
+set(CMAKE_SHARED_LIBRARY_PREFIX "")
+if(UNIX)
+    set(CMAKE_SHARED_LIBRARY_SUFFIX ".wlx")
+endif()
+
+find_package(Qt6 REQUIRED COMPONENTS Core Gui Widgets OpenGLWidgets)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(MPV REQUIRED mpv)
+
+include_directories(
+    ${CMAKE_CURRENT_SOURCE_DIR}/sdk
+    ${MPV_INCLUDE_DIRS}
+)
+
+add_library(mpv_wayland SHARED
+    src/main.cpp
+    src/mpvwidget.cpp
+)
+
+target_link_libraries(mpv_wayland
+    PRIVATE
+    Qt6::Core
+    Qt6::Gui
+    Qt6::Widgets
+    Qt6::OpenGLWidgets
+    ${MPV_LIBRARIES}
+)
+
+# extra-cmake-modules (ECM) is required per goal.md
+find_package(ECM 5.80.0 REQUIRED NO_MODULE)
+set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH})
+include(KDEInstallDirs)
+include(KDECMakeSettings)
+include(KDECompilerSettings NO_POLICY_SCOPE)

--- a/plugins/wlx/mpv_wayland/README.md
+++ b/plugins/wlx/mpv_wayland/README.md
@@ -1,0 +1,50 @@
+# mpv_wayland Double Commander Plugin
+
+A native WLX (Lister) plugin for Double Commander allowing video playback in the Quick View panel. This plugin uses the `libmpv` Render API and `QOpenGLWidget`, offering seamless, high-performance video embedding, particularly well-suited for Wayland and HiDPI displays.
+
+This plugin evolved from the `mpv_alt` plugin, modernizing video rendering by removing legacy X11 window-ID (`wid`) embedding, making it fully compatible with Wayland compositors.
+
+## Features
+- Native Qt6 rendering using `QOpenGLWidget` and the `mpv_render_context`.
+- Wayland native rendering and HiDPI pixel ratio awareness.
+- Full On-Screen Controller (OSC) support via Qt mouse event mapping.
+- Dedicated keyboard handling bypassing the Double Commander global intercepts.
+- Synchronized rendering updates utilizing the Qt `QueuedConnection` mechanism.
+
+## Dependencies
+- **Qt6**: Core, Gui, Widgets, OpenGLWidgets
+- **libmpv**: `mpv` development libraries (`libmpv-dev` / `mpv`)
+- **CMake**: `cmake` and `extra-cmake-modules` (KDE CMake modules)
+- **Make** or **Ninja**
+
+**Debian/Ubuntu:**
+```bash
+sudo apt install build-essential cmake extra-cmake-modules qt6-base-dev libmpv-dev
+```
+
+**Arch Linux:**
+```bash
+sudo pacman -S base-devel cmake extra-cmake-modules qt6-base mpv
+```
+
+## Compilation
+
+```bash
+mkdir build
+cd build
+cmake ..
+make
+```
+
+The resulting build will yield a file named `mpv_wayland.wlx` inside the `build/` directory.
+
+## Installation
+
+1. Open Double Commander.
+2. Navigate to **Configuration > Options > Plugins > Plugins WLX**.
+3. Click **Add** and select the newly built `mpv_wayland.wlx` file.
+4. Ensure it has priority over other viewer plugins for video extensions (e.g., `.mkv`, `.mp4`).
+
+## Keyboard and Controls
+Hovering the mouse across the bottom of the video panel triggers the `libmpv` On Screen Controller (OSC).
+Alternatively, you may click on the video panel to grab the keyboard context. This enables `libmpv`'s default keybindings (e.g., Space for Play/Pause, arrow keys for seeking).

--- a/plugins/wlx/mpv_wayland/sdk/common.h
+++ b/plugins/wlx/mpv_wayland/sdk/common.h
@@ -1,0 +1,81 @@
+#ifndef _COMMON_H
+#define _COMMON_H
+
+#ifdef __GNUC__
+
+#include <stdint.h>
+
+#if defined(__WIN32__) || defined(_WIN32) || defined(_WIN64)
+  #define DCPCALL __attribute__((stdcall))
+#else
+  #define DCPCALL
+#endif
+
+#define MAX_PATH 260
+
+typedef int32_t LONG;
+typedef uint32_t DWORD;
+typedef uint16_t WORD;
+typedef void *HANDLE;
+typedef HANDLE HICON;
+typedef HANDLE HBITMAP;
+typedef HANDLE HWND;
+typedef int BOOL;
+typedef char CHAR;
+typedef uint16_t WCHAR;
+typedef intptr_t LPARAM;
+typedef uintptr_t WPARAM;
+
+#pragma pack(push, 1)
+
+typedef struct _RECT {
+  LONG left;
+  LONG top;
+  LONG right;
+  LONG bottom;
+} RECT, *PRECT;
+
+typedef struct _FILETIME {
+	DWORD dwLowDateTime;
+	DWORD dwHighDateTime;
+} FILETIME,*PFILETIME,*LPFILETIME;
+
+typedef struct _WIN32_FIND_DATAA {
+	DWORD dwFileAttributes;
+	FILETIME ftCreationTime;
+	FILETIME ftLastAccessTime;
+	FILETIME ftLastWriteTime;
+	DWORD nFileSizeHigh;
+	DWORD nFileSizeLow;
+	DWORD dwReserved0;
+	DWORD dwReserved1;
+	CHAR cFileName[MAX_PATH];
+	CHAR cAlternateFileName[14];
+} WIN32_FIND_DATAA,*LPWIN32_FIND_DATAA;
+
+typedef struct _WIN32_FIND_DATAW {
+	DWORD dwFileAttributes;
+	FILETIME ftCreationTime;
+	FILETIME ftLastAccessTime;
+	FILETIME ftLastWriteTime;
+	DWORD nFileSizeHigh;
+	DWORD nFileSizeLow;
+	DWORD dwReserved0;
+	DWORD dwReserved1;
+	WCHAR cFileName[MAX_PATH];
+	WCHAR cAlternateFileName[14];
+} WIN32_FIND_DATAW,*LPWIN32_FIND_DATAW;
+
+#pragma pack(pop)
+
+#else
+
+#if defined(_WIN32) || defined(_WIN64)
+  #define DCPCALL __stdcall
+#else
+  #define DCPCALL __cdecl
+#endif
+
+#endif
+
+#endif // _COMMON_H

--- a/plugins/wlx/mpv_wayland/sdk/wlxplugin.h
+++ b/plugins/wlx/mpv_wayland/sdk/wlxplugin.h
@@ -1,0 +1,75 @@
+#ifndef _WLX_H
+#define _WLX_H
+
+#include "common.h"
+
+/* Contents of file listplug.h */
+
+#define lc_copy		1
+#define lc_newparams	2
+#define lc_selectall	3
+#define lc_setpercent	4
+
+#define lcp_wraptext	1
+#define lcp_fittowindow 2
+#define lcp_ansi		4
+#define lcp_ascii		8
+#define lcp_variable	12
+#define lcp_forceshow	16
+#define lcp_fitlargeronly 32
+#define lcp_center	64
+
+#define lcs_findfirst	1
+#define lcs_matchcase	2
+#define lcs_wholewords	4
+#define lcs_backwards	8
+
+#define itm_percent	0xFFFE
+#define itm_fontstyle	0xFFFD
+#define itm_wrap		0xFFFC
+#define itm_fit		0xFFFB
+#define itm_next		0xFFFA
+#define itm_center	0xFFF9
+
+#define LISTPLUGIN_OK	0
+
+#define LISTPLUGIN_ERROR	1
+
+typedef struct {
+	int size;
+	DWORD PluginInterfaceVersionLow;
+	DWORD PluginInterfaceVersionHi;
+	char DefaultIniName[MAX_PATH];
+} ListDefaultParamStruct;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+HWND DCPCALL ListLoad(HWND ParentWin,char* FileToLoad,int ShowFlags);
+HWND DCPCALL ListLoadW(HWND ParentWin,WCHAR* FileToLoad,int ShowFlags);
+int DCPCALL ListLoadNext(HWND ParentWin,HWND PluginWin,char* FileToLoad,int ShowFlags);
+int DCPCALL ListLoadNextW(HWND ParentWin,HWND PluginWin,WCHAR* FileToLoad,int ShowFlags);
+void DCPCALL ListCloseWindow(HWND ListWin);
+void DCPCALL ListGetDetectString(char* DetectString,int maxlen);
+int DCPCALL ListSearchText(HWND ListWin,char* SearchString,int SearchParameter);
+int DCPCALL ListSearchTextW(HWND ListWin,WCHAR* SearchString,int SearchParameter);
+
+int DCPCALL ListSearchDialog(HWND ListWin,int FindNext);
+int DCPCALL ListSendCommand(HWND ListWin,int Command,int Parameter);
+int DCPCALL ListPrint(HWND ListWin,char* FileToPrint,char* DefPrinter,
+                        int PrintFlags,RECT* Margins);
+int DCPCALL ListPrintW(HWND ListWin,WCHAR* FileToPrint,WCHAR* DefPrinter,
+                        int PrintFlags,RECT* Margins);
+int DCPCALL ListNotificationReceived(HWND ListWin,int Message,WPARAM wParam,LPARAM lParam);
+void DCPCALL ListSetDefaultParams(ListDefaultParamStruct* dps);
+HBITMAP DCPCALL ListGetPreviewBitmap(char* FileToLoad,int width,int height,
+    char* contentbuf,int contentbuflen);
+HBITMAP DCPCALL ListGetPreviewBitmapW(WCHAR* FileToLoad,int width,int height,
+    char* contentbuf,int contentbuflen);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // _WLX_H

--- a/plugins/wlx/mpv_wayland/src/main.cpp
+++ b/plugins/wlx/mpv_wayland/src/main.cpp
@@ -1,0 +1,116 @@
+#include "wlxplugin.h"
+#include "mpvwidget.h"
+#include <QCoreApplication>
+#include <QWidget>
+#include <cstdio>
+
+extern "C" {
+
+HWND DCPCALL ListLoad(HWND ParentWin, char* FileToLoad, int ShowFlags)
+{
+    (void)ShowFlags;
+
+    if (!QCoreApplication::instance()) {
+        return nullptr;
+    }
+
+    QWidget *parent = static_cast<QWidget*>(ParentWin);
+    MpvWidget *view = new MpvWidget(parent);
+    
+    if (view->loadFile(QString::fromUtf8(FileToLoad))) {
+        view->show();
+        return static_cast<HWND>(view);
+    } else {
+        delete view;
+        return nullptr;
+    }
+}
+
+HWND DCPCALL ListLoadW(HWND ParentWin, WCHAR* FileToLoad, int ShowFlags)
+{
+    (void)ShowFlags;
+
+    if (!QCoreApplication::instance()) {
+        return nullptr;
+    }
+
+    // QString::fromWCharArray works with wchar_t*, but WCHAR is uint16_t in common.h
+    QString fileName = QString::fromUtf16(reinterpret_cast<const char16_t*>(FileToLoad));
+    
+    QWidget *parent = static_cast<QWidget*>(ParentWin);
+    MpvWidget *view = new MpvWidget(parent);
+    
+    if (view->loadFile(fileName)) {
+        view->show();
+        return static_cast<HWND>(view);
+    } else {
+        delete view;
+        return nullptr;
+    }
+}
+
+int DCPCALL ListLoadNext(HWND ParentWin, HWND PluginWin, char* FileToLoad, int ShowFlags)
+{
+    (void)ParentWin;
+    (void)ShowFlags;
+    
+    MpvWidget *view = static_cast<MpvWidget*>(PluginWin);
+    if (!view) return LISTPLUGIN_ERROR;
+
+    if (view->loadFile(QString::fromUtf8(FileToLoad))) {
+        return LISTPLUGIN_OK;
+    }
+    return LISTPLUGIN_ERROR;
+}
+
+int DCPCALL ListLoadNextW(HWND ParentWin, HWND PluginWin, WCHAR* FileToLoad, int ShowFlags)
+{
+    (void)ParentWin;
+    (void)ShowFlags;
+    
+    MpvWidget *view = static_cast<MpvWidget*>(PluginWin);
+    if (!view) return LISTPLUGIN_ERROR;
+
+    QString fileName = QString::fromUtf16(reinterpret_cast<const char16_t*>(FileToLoad));
+    if (view->loadFile(fileName)) {
+        return LISTPLUGIN_OK;
+    }
+    return LISTPLUGIN_ERROR;
+}
+
+void DCPCALL ListCloseWindow(HWND ListWin)
+{
+    MpvWidget *view = static_cast<MpvWidget*>(ListWin);
+    if (view) {
+        view->closeFile();
+        delete view;
+    }
+}
+
+void DCPCALL ListGetDetectString(char* DetectString, int maxlen)
+{
+    // Basic detection for video/audio files
+    snprintf(DetectString, maxlen, "EXT=\"MKV\" | EXT=\"MP4\" | EXT=\"AVI\" | EXT=\"MOV\" | EXT=\"MP3\" | EXT=\"FLAC\" | EXT=\"WAV\" | EXT=\"OGG\" | EXT=\"WEBM\"");
+}
+
+int DCPCALL ListSearchDialog(HWND ListWin, int FindNext)
+{
+    (void)ListWin;
+    (void)FindNext;
+    return LISTPLUGIN_OK;
+}
+
+int DCPCALL ListSendCommand(HWND ListWin, int Command, int Parameter)
+{
+    (void)ListWin;
+    (void)Command;
+    (void)Parameter;
+    return LISTPLUGIN_ERROR;
+}
+
+void DCPCALL ListSetDefaultParams(ListDefaultParamStruct* dps)
+{
+    (void)dps;
+}
+
+} // extern "C"

--- a/plugins/wlx/mpv_wayland/src/mpvwidget.cpp
+++ b/plugins/wlx/mpv_wayland/src/mpvwidget.cpp
@@ -1,0 +1,312 @@
+#include "mpvwidget.h"
+#include <QOpenGLContext>
+#include <QWindow>
+#include <QDebug>
+#include <clocale>
+#include <QMouseEvent>
+#include <QWheelEvent>
+#include <QKeyEvent>
+#include <QCoreApplication>
+
+MpvWidget::MpvWidget(QWidget *parent)
+    : QOpenGLWidget(parent)
+    , m_mpv(nullptr)
+    , m_mpvGL(nullptr)
+    , m_glReady(false)
+{
+    setWindowFlags(Qt::Widget);
+    setAttribute(Qt::WA_NativeWindow);
+    setMouseTracking(true); // Needed so we get hover events for the OSC
+    setFocusPolicy(Qt::WheelFocus); // Accepts keyboard inputs including wheel focus
+
+    if (QCoreApplication::instance()) {
+        QCoreApplication::instance()->installEventFilter(this);
+    }
+
+    // mpv requires LC_NUMERIC=C or it will refuse to initialize
+    setlocale(LC_NUMERIC, "C");
+
+    m_mpv = mpv_create();
+    if (!m_mpv) {
+        qCritical() << "mpv_wayland: mpv_create() failed";
+        return;
+    }
+
+    // Use the Render API — no native window embedding
+    mpv_set_option_string(m_mpv, "vo", "libmpv");
+    mpv_set_option_string(m_mpv, "keep-open", "yes");
+    mpv_set_option_string(m_mpv, "hwdec", "no");
+    // Enable the On Screen Controller
+    mpv_set_option_string(m_mpv, "osc", "yes");
+    // Suppress terminal output from mpv
+    mpv_set_option_string(m_mpv, "terminal", "no");
+    mpv_set_option_string(m_mpv, "msg-level", "all=no");
+    
+    // Enable default keybindings so our mapped keypresses actually do something
+    mpv_set_option_string(m_mpv, "input-default-bindings", "yes");
+    // Enable input to the OSC
+    mpv_set_option_string(m_mpv, "input-vo-keyboard", "yes");
+
+    int err = mpv_initialize(m_mpv);
+    if (err < 0) {
+        qCritical() << "mpv_wayland: mpv_initialize() failed:" << err;
+        mpv_terminate_destroy(m_mpv);
+        m_mpv = nullptr;
+        return;
+    }
+}
+
+MpvWidget::~MpvWidget()
+{
+    if (QCoreApplication::instance()) {
+        QCoreApplication::instance()->removeEventFilter(this);
+    }
+
+    makeCurrent();
+    if (m_mpvGL) {
+        mpv_render_context_free(m_mpvGL);
+        m_mpvGL = nullptr;
+    }
+    doneCurrent();
+    if (m_mpv) {
+        mpv_terminate_destroy(m_mpv);
+        m_mpv = nullptr;
+    }
+}
+
+void MpvWidget::on_update(void *ctx)
+{
+    MpvWidget *widget = static_cast<MpvWidget*>(ctx);
+    // Thread-safe: callback comes from mpv's background thread, post to Qt main loop
+    QMetaObject::invokeMethod(widget, "onMpvUpdate", Qt::QueuedConnection);
+}
+
+void *MpvWidget::get_proc_address(void *ctx, const char *name)
+{
+    Q_UNUSED(ctx);
+    QOpenGLContext *glctx = QOpenGLContext::currentContext();
+    if (!glctx) return nullptr;
+    return reinterpret_cast<void*>(glctx->getProcAddress(name));
+}
+
+void MpvWidget::initializeGL()
+{
+    if (!m_mpv) {
+        qCritical() << "mpv_wayland: initializeGL called but m_mpv is null";
+        return;
+    }
+
+    mpv_opengl_init_params gl_init_params = {
+        get_proc_address,
+        nullptr
+    };
+
+    mpv_render_param params[] = {
+        {MPV_RENDER_PARAM_API_TYPE, (void *)MPV_RENDER_API_TYPE_OPENGL},
+        {MPV_RENDER_PARAM_OPENGL_INIT_PARAMS, &gl_init_params},
+        {MPV_RENDER_PARAM_INVALID, nullptr}
+    };
+
+    int err = mpv_render_context_create(&m_mpvGL, m_mpv, params);
+    if (err < 0) {
+        qCritical() << "mpv_wayland: mpv_render_context_create() failed:" << err;
+        return;
+    }
+
+    mpv_render_context_set_update_callback(m_mpvGL, on_update, this);
+    m_glReady = true;
+
+    // If a file was queued before GL was ready, load it now
+    if (!m_pendingFile.isEmpty()) {
+        QMetaObject::invokeMethod(this, "doLoadFile", Qt::QueuedConnection);
+    }
+}
+
+void MpvWidget::paintGL()
+{
+    if (!m_mpvGL) return;
+
+    // Use physical pixels for Wayland HiDPI scaling
+    qreal dpr = devicePixelRatioF();
+    int w = static_cast<int>(width() * dpr);
+    int h = static_cast<int>(height() * dpr);
+    int fbo = defaultFramebufferObject();
+
+    mpv_opengl_fbo mpfbo = {
+        fbo,
+        w,
+        h,
+        0
+    };
+
+    int flip_y = 1;
+
+    mpv_render_param params[] = {
+        {MPV_RENDER_PARAM_OPENGL_FBO, &mpfbo},
+        {MPV_RENDER_PARAM_FLIP_Y, &flip_y},
+        {MPV_RENDER_PARAM_INVALID, nullptr}
+    };
+
+    mpv_render_context_render(m_mpvGL, params);
+}
+
+void MpvWidget::resizeGL(int w, int h)
+{
+    Q_UNUSED(w);
+    Q_UNUSED(h);
+}
+
+bool MpvWidget::loadFile(const QString &fileName)
+{
+    if (!m_mpv) return false;
+
+    m_pendingFile = fileName;
+
+    if (m_glReady) {
+        // GL is already ready, load immediately
+        doLoadFile();
+        return true;
+    }
+
+    // GL not ready yet — file will be loaded in initializeGL via deferred call
+    return true;
+}
+
+void MpvWidget::doLoadFile()
+{
+    if (!m_mpv || m_pendingFile.isEmpty()) return;
+
+    QByteArray utf8 = m_pendingFile.toUtf8();
+    const char *args[] = {"loadfile", utf8.constData(), nullptr};
+    int err = mpv_command(m_mpv, args);
+
+    if (err < 0) {
+        qCritical() << "mpv_wayland: loadfile failed:" << err << m_pendingFile;
+    }
+}
+
+void MpvWidget::closeFile()
+{
+    if (!m_mpv) return;
+    const char *args[] = {"stop", nullptr};
+    mpv_command(m_mpv, args);
+    m_pendingFile.clear();
+}
+
+void MpvWidget::onMpvUpdate()
+{
+    update();
+}
+
+void MpvWidget::mouseMoveEvent(QMouseEvent *event)
+{
+    if (!m_mpv) return;
+    int x = event->x() * devicePixelRatioF();
+    int y = event->y() * devicePixelRatioF();
+    QString cmd = QString("mouse %1 %2").arg(x).arg(y);
+    mpv_command_string(m_mpv, cmd.toUtf8().constData());
+}
+
+void MpvWidget::mousePressEvent(QMouseEvent *event)
+{
+    setFocus(); // Explicitly request focus when clicked so we can receive keyboard events
+    grabKeyboard(); // Force grab all keyboard input (prevents Double Commander from stealing it)
+
+    if (!m_mpv) return;
+    if (event->button() == Qt::LeftButton) {
+        mpv_command_string(m_mpv, "keydown MOUSE_BTN0");
+    } else if (event->button() == Qt::RightButton) {
+        mpv_command_string(m_mpv, "keydown MOUSE_BTN2");
+    }
+}
+
+void MpvWidget::mouseReleaseEvent(QMouseEvent *event)
+{
+    if (!m_mpv) return;
+    if (event->button() == Qt::LeftButton) {
+        mpv_command_string(m_mpv, "keyup MOUSE_BTN0");
+    } else if (event->button() == Qt::RightButton) {
+        mpv_command_string(m_mpv, "keyup MOUSE_BTN2");
+    }
+}
+
+void MpvWidget::wheelEvent(QWheelEvent *event)
+{
+    if (!m_mpv) return;
+    if (event->angleDelta().y() > 0) {
+        mpv_command_string(m_mpv, "keypress WHEEL_UP");
+    } else {
+        mpv_command_string(m_mpv, "keypress WHEEL_DOWN");
+    }
+}
+
+void MpvWidget::leaveEvent(QEvent *event)
+{
+    if (!m_mpv) return;
+    // Release keyboard grab if the user moves their mouse away from the video
+    releaseKeyboard();
+    
+    // Move mouse out of frame to hide OSC
+    mpv_command_string(m_mpv, "mouse -100 -100");
+}
+
+QString MpvWidget::mapQtKeyToMpvKey(QKeyEvent *event)
+{
+    switch(event->key()) {
+        case Qt::Key_Space: return "SPACE";
+        case Qt::Key_Left: return "LEFT";
+        case Qt::Key_Right: return "RIGHT";
+        case Qt::Key_Up: return "UP";
+        case Qt::Key_Down: return "DOWN";
+        case Qt::Key_Enter:
+        case Qt::Key_Return: return "ENTER";
+        case Qt::Key_Escape: return "ESC";
+        case Qt::Key_Backspace: return "BS";
+        case Qt::Key_PageUp: return "PGUP";
+        case Qt::Key_PageDown: return "PGDWN";
+        case Qt::Key_Home: return "HOME";
+        case Qt::Key_End: return "END";
+        case Qt::Key_Tab: return "TAB";
+    }
+    // Return the text character if available
+    QString text = event->text();
+    if (!text.isEmpty()) {
+        return text;
+    }
+    return "";
+}
+
+void MpvWidget::keyPressEvent(QKeyEvent *event)
+{
+    if (!m_mpv) return;
+    QString mpvKey = mapQtKeyToMpvKey(event);
+    if (!mpvKey.isEmpty()) {
+        QString cmd = QString("keypress %1").arg(mpvKey); // Send keypress directly instead of keydown to avoid stuck keys
+        mpv_command_string(m_mpv, cmd.toUtf8().constData());
+    }
+}
+
+void MpvWidget::keyReleaseEvent(QKeyEvent *event)
+{
+    // Ignore key release since we sent a full keypress above.
+    // If you need exact down/up tracking, this can be reverted to keyup.
+    Q_UNUSED(event);
+}
+
+bool MpvWidget::eventFilter(QObject *obj, QEvent *event)
+{
+    if (event->type() == QEvent::KeyPress || event->type() == QEvent::KeyRelease) {
+        // If the mouse is hovering over the video, steal all keyboard events globally
+        if (underMouse() || hasFocus()) {
+            QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
+            if (event->type() == QEvent::KeyPress) {
+                keyPressEvent(keyEvent);
+            } else {
+                keyReleaseEvent(keyEvent);
+            }
+            return true; // Eat the event so DC doesn't get it
+        }
+    }
+    return QOpenGLWidget::eventFilter(obj, event);
+}
+

--- a/plugins/wlx/mpv_wayland/src/mpvwidget.h
+++ b/plugins/wlx/mpv_wayland/src/mpvwidget.h
@@ -1,0 +1,50 @@
+#ifndef MPVWIDGET_H
+#define MPVWIDGET_H
+
+#include <QOpenGLWidget>
+#include <QOpenGLFunctions>
+#include <QString>
+#include <mpv/client.h>
+#include <mpv/render_gl.h>
+
+class MpvWidget : public QOpenGLWidget
+{
+    Q_OBJECT
+
+public:
+    explicit MpvWidget(QWidget *parent = nullptr);
+    ~MpvWidget();
+
+    bool loadFile(const QString &fileName);
+    void closeFile();
+
+protected:
+    void initializeGL() override;
+    void paintGL() override;
+    void resizeGL(int w, int h) override;
+
+    void mouseMoveEvent(QMouseEvent *event) override;
+    void mousePressEvent(QMouseEvent *event) override;
+    void mouseReleaseEvent(QMouseEvent *event) override;
+    void wheelEvent(QWheelEvent *event) override;
+    void leaveEvent(QEvent *event) override;
+    void keyPressEvent(QKeyEvent *event) override;
+    void keyReleaseEvent(QKeyEvent *event) override;
+    bool eventFilter(QObject *obj, QEvent *event) override;
+
+private slots:
+    void onMpvUpdate();
+    void doLoadFile();
+
+private:
+    static void on_update(void *ctx);
+    static void *get_proc_address(void *ctx, const char *name);
+    QString mapQtKeyToMpvKey(QKeyEvent *event);
+
+    mpv_handle *m_mpv;
+    mpv_render_context *m_mpvGL;
+    QString m_pendingFile;
+    bool m_glReady;
+};
+
+#endif // MPVWIDGET_H


### PR DESCRIPTION
# Description
This Pull Request introduces a new WLX (Lister) plugin, **mpv_wayland**, designed specifically to address the limitations of existing mpv plugins (like `mpv_alt`) when running under **Wayland**.

While `mpv_alt` works well on X11, it relies on legacy window-ID (`wid`) embedding which is not supported natively by Wayland compositors. This results in either a failure to render or the creation of an unwanted standalone window.

# Key Features & Technical Improvements

*   **libmpv Render API Integration**: Instead of window embedding, this plugin uses a custom `QOpenGLWidget` and the `mpv_render_context` to draw video frames directly into the plugin’s shared OpenGL framebuffer.
*   **Wayland Native & HiDPI Aware**: Automatically handles display scaling using `devicePixelRatioF()`, ensuring the video remains sharp and correctly aligned on high-density displays.
*   **Fully Interactive OSC**: Since `libmpv` in render-mode does not handle input, this plugin manually maps and forwards Qt mouse events to the `mpv` core. This enables the built-in On Screen Controller (OSC) to be fully interactive (hovering, seeking, and playing).
*   **Global Keyboard Control**: Implements a Qt `eventFilter` and a `StrongFocus` policy to capture keyboard shortcuts (Space, Arrows, M, etc.). This bypasses the typical host-application (Double Commander) key interception, allowing standard mpv controls to work directly in the Quick View panel.
*   **Robust Initialization**: 
    *   Forces `LC_NUMERIC="C"` (required by `libmpv`).
    *   Defers file loading until the OpenGL context is fully established to prevent black-screen race conditions.
    *   Suppresses harmless hardware decoding library warnings (`libcuda`/`vdpau`) on non-NVIDIA systems.

# Dependencies
* Qt6 (Core, Gui, Widgets, OpenGLWidgets)
* libmpv
* extra-cmake-modules (ECM)

# How to Test
1. Compile using CMake.
2. Add `mpv_wayland.wlx` to Double Commander's WLX plugins.
3. Open a video in the Quick View panel (`Ctrl+Q`).
4. **Mouse**: Hover near the bottom to see/use the OSC.
5. **Keyboard**: Click once on the video to grab focus, then use `Space` to Play/Pause or `Arrows` to seek.

# Motivation
To provide a first-class, modern video playback experience for Double Commander users on modern Wayland-based Linux distributions.