### PR TITLE
wlx/md4c*: keep MD_DIALECT_GITHUB in ListLoadNext

### DIFF
--- a/plugins/wlx/md4c_qt/src/plugin.cpp
+++ b/plugins/wlx/md4c_qt/src/plugin.cpp
@@ -58,7 +58,7 @@ int DCPCALL ListLoadNext(HWND ParentWin, HWND PluginWin, char* FileToLoad, int S
 	QByteArray text = file.readAll();
 	file.close();
 
-	if (md_html(text.data(), text.size(), proc_md_cb, &html_str, 0, MD_HTML_FLAG_SKIP_UTF8_BOM) != 0)
+	if (md_html(text.data(), text.size(), proc_md_cb, &html_str, MD_DIALECT_GITHUB, MD_HTML_FLAG_SKIP_UTF8_BOM) != 0)
 		return LISTPLUGIN_ERROR;
 
 	QTextBrowser *view = (QTextBrowser*)PluginWin;

--- a/plugins/wlx/md4c_webkit/src/plugin.c
+++ b/plugins/wlx/md4c_webkit/src/plugin.c
@@ -99,7 +99,7 @@ int DCPCALL ListLoadNext(HWND ParentWin, HWND PluginWin, char* FileToLoad, int S
 
 	GString *res = g_string_new(NULL);
 
-	if (md_html(contents, length, proc_md_cb, res, 0, MD_HTML_FLAG_SKIP_UTF8_BOM) != 0)
+	if (md_html(contents, length, proc_md_cb, res, MD_DIALECT_GITHUB, MD_HTML_FLAG_SKIP_UTF8_BOM) != 0)
 	{
 		g_free(contents);
 		g_string_free(res, TRUE);

--- a/plugins/wlx/md4c_webkit_qt/src/plugin.cpp
+++ b/plugins/wlx/md4c_webkit_qt/src/plugin.cpp
@@ -60,7 +60,7 @@ int DCPCALL ListLoadNext(HWND ParentWin, HWND PluginWin, char* FileToLoad, int S
 	QByteArray text = file.readAll();
 	file.close();
 
-	if (md_html(text.data(), text.size(), proc_md_cb, &html_str, 0, MD_HTML_FLAG_SKIP_UTF8_BOM) != 0)
+	if (md_html(text.data(), text.size(), proc_md_cb, &html_str, MD_DIALECT_GITHUB, MD_HTML_FLAG_SKIP_UTF8_BOM) != 0)
 		return LISTPLUGIN_ERROR;
 
 	QWebView *webView = (QWebView*)PluginWin;


### PR DESCRIPTION
`ListLoad` parses Markdown with `MD_DIALECT_GITHUB`, but `ListLoadNext` passes `0` instead. As a result the same file renders differently depending on how it is opened: tables, strikethrough and task lists are lost when switching to the next file in an already open lister window (or in Quick View).

Affects three plugins that share this code: `md4c_qt`, `md4c_webkit`, `md4c_webkit_qt`.

**Steps to reproduce:** open a Markdown file containing a GFM table with F3 - the table renders. Without closing the lister, move to another Markdown file - the table is now shown as raw text with pipe characters.

Tested on Double Commander 1.2.8 (Qt6), Kubuntu 26.04, md4c 0.5.2.