### PR TITLE
README: add adb-wfx (ADB file-system plugin for Android devices)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,4 @@ Cross-platform or for Linux only.
 - [Total/Double Commander WFX file-system plugin for X4/MicroReader e-readers (USB serial)](https://github.com/jpirnay/x4-filemanager-plugin)<br>
 - [Native macOS plugins for Double Commander](https://github.com/NikolaiSachok/DC-plugins)<br>
 - [Plugins for Double Commander to work with ZX Spectrum .trd, .scl disk images](https://github.com/alffcpu/dc-trd-scl-plugins)<br>
+- [WFX plugin to browse Android devices over ADB, preserving modification dates (macOS, Linux)](https://github.com/vmurin/adb-wfx-plugin)<br>


### PR DESCRIPTION
Adds one line to the **Also see** list.

### What it is

[adb-wfx](https://github.com/vmurin/adb-wfx-plugin) is a WFX file-system plugin that browses, copies, renames and deletes files on an Android device over ADB. It speaks the `adb` server's wire protocol directly (`host:`, `sync` v1, `shell:`) rather than shelling out to the `adb` command-line tool for every operation.

### Why another Android plugin

Modification dates. Over MTP an uploaded file ends up stamped with the moment of the copy, and the device offers no way to correct it. ADB's sync protocol carries the real mtime in both directions, so a file keeps its date whether it is copied to the phone or from it. It is also measurably faster than MTP on the same corpus.

`FsSetTimeW` is exported deliberately and permanently, since DC strips `caoCopyTime` from every copy — downloads included — when neither `FsSetTime` nor `FsSetTimeW` is present ([doublecmd#3051](https://github.com/doublecmd/doublecmd/issues/3051)).

### Details

- MIT licensed, C++17, no dependencies beyond a compiler and `adb` itself.
- Prebuilt binaries in [Releases](https://github.com/vmurin/adb-wfx-plugin/releases/latest): macOS universal (arm64 + x86_64), Linux x86_64, Linux aarch64. Each archive carries a `pluginst.inf`.
- ~900 unit checks run in CI on macOS (arm64, x86_64) and Linux (x86_64, aarch64), plus an opt-in end-to-end suite against a real device.
- macOS is hardware-confirmed on a Pixel 7. **The Linux builds are untested on real hardware** — they compile and pass the full unit suite in CI, but nobody has yet run them against an actual device inside Double Commander. This is stated plainly in the README and in the release notes rather than glossed over.

Happy to reword or move the entry if you would rather have it somewhere else.